### PR TITLE
Change regex to match change URL of workout detail pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.1.2
+ - Fixed regex to extract workout ID after Garmin has changed the URL structure
 ## 1.1.1
  - Added support to connect.garmin.cn
 ## 1.1.0

--- a/share-your-workout.js
+++ b/share-your-workout.js
@@ -72,8 +72,9 @@ class GarminShare {
 	static getWorkout(){
 		let workoutID = document.URL.split('/').slice(-1).pop();
 		let queryString = '?includeAudioNotes=true&_=' + Date.now();
-		if(workoutID.match(new RegExp('^[0-9]+$'))){
-			GarminShare.ajaxRequest('GET', GarminShare.getWorkoutEndpoint + workoutID + queryString, GarminShare.injectShareButton);
+		let workoutMatchID = workoutID.match(new RegExp('^([0-9]+)'))
+		if (workoutMatchID.length > 0){
+			GarminShare.ajaxRequest('GET', GarminShare.getWorkoutEndpoint + workoutMatchID[0] + queryString, GarminShare.injectShareButton);
 		}
 	}
 }


### PR DESCRIPTION
Garmin has changed the URL pattern adding a query string that breaks the regex used to extract the Workout ID.
Change the regex to fix the issue