### PR TITLE
[NO-ISSUE] Fix authentication to use CSRF token instead of Bearer token

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "__MSG_extName__",
-	"version": "1.4.0",
+	"version": "1.5.0",
 	"description": "__MSG_extDescription__",
 	"default_locale": "en",
 	"author": "Filippo Pisano",


### PR DESCRIPTION
Garmin has changed their API authentication from Bearer tokens to CSRF tokens. Updated both GarminShare and GarminImport classes to:
- Extract CSRF token from meta tag instead of localStorage
- Use connect-csrf-token header instead of authorization Bearer
- Update API endpoints to use /gc-api/ path prefix

Version bumped to 1.5.0