### PR TITLE
fix(ui): support new Garmin Connect /app/ workouts UI

### DIFF
--- a/share-your-workout.js
+++ b/share-your-workout.js
@@ -358,11 +358,17 @@ class GarminImport {
 		let btn = document.querySelector(GarminImport.createWorkoutButtonSelector);
 		if (btn) return btn;
 
-		// Priority 2: New interface - find button inside WorkoutsCreate container
-		const newContainer = document.querySelector('[class*="WorkoutsCreate_workoutCreate"]');
-		if (newContainer) {
-			btn = newContainer.querySelector('button[class*=Button_primary]');
-			if (btn) return btn;
+		// Priority 2: New interface - find button inside known container variants
+		const containerSelectors = [
+			'[class*="WorkoutsListContainer_createWorkoutButton"]',
+			'[class*="WorkoutsCreate_workoutCreate"]'
+		];
+		for (const selector of containerSelectors) {
+			const container = document.querySelector(selector);
+			if (container) {
+				btn = container.querySelector('button[class*=Button_primary]') || container.querySelector('button');
+				if (btn) return btn;
+			}
 		}
 
 		// Priority 3: Text content fallback (using Array.from for cleaner iteration)
@@ -527,18 +533,22 @@ class GarminEvent {
 		let currentUrl = window.location.href;
 		let body = document.body;
 
-		// Check for workout index page (workouts list) - supports both /modern/workouts and /app/workouts
-		if ((currentUrl.includes('/modern/workouts') || currentUrl.includes('/app/workouts') || currentUrl.includes('/workouts')) &&
-			(body.classList.contains('body-workouts-index') || GarminImport.getCreateWorkoutButton() || document.querySelector('[class*="WorkoutsCreate"]'))) {
-			GarminEvent.dispatchEvent('GarminImportWorkoutReady');
+		// Check for individual workout page first (more specific match).
+		// Matches /workout/{id}, /workouts/{id}, and /modern/ or /app/ prefixed variants.
+		if (/\/workouts?\/\d+/.test(currentUrl) &&
+			(body.classList.contains('body-workout') || body.classList.contains('body-workoutPage') ||
+				document.querySelector(GarminShare.sendButtonSelector) ||
+				document.querySelector(GarminShare.sendButtonAlternativeSelector) ||
+				document.querySelector('[class*="WorkoutPageContent"]') ||
+				document.querySelector('[class*="WorkoutPageHeader"]'))) {
+			GarminEvent.dispatchEvent('GarminShareWorkoutReady');
 			return true;
 		}
 
-		// Check for individual workout page - supports both /modern/workout/ and /app/workout/
-		if ((currentUrl.includes('/modern/workout/') || currentUrl.includes('/app/workout/') || currentUrl.includes('/workout/')) &&
-			(body.classList.contains('body-workout') || body.classList.contains('body-workoutPage') ||
-				document.querySelector(GarminShare.sendButtonSelector) || document.querySelector(GarminShare.sendButtonAlternativeSelector))) {
-			GarminEvent.dispatchEvent('GarminShareWorkoutReady');
+		// Check for workout index page (workouts list) - supports both /modern/workouts and /app/workouts
+		if ((currentUrl.includes('/modern/workouts') || currentUrl.includes('/app/workouts') || currentUrl.includes('/workouts')) &&
+			(body.classList.contains('body-workouts-index') || GarminImport.getCreateWorkoutButton() || document.querySelector('[class*="WorkoutsCreate"]') || document.querySelector('[class*="WorkoutsListContainer"]'))) {
+			GarminEvent.dispatchEvent('GarminImportWorkoutReady');
 			return true;
 		}
 

--- a/share-your-workout.js
+++ b/share-your-workout.js
@@ -435,7 +435,9 @@ class GarminImport {
 						try {
 							let copiedWorkout = JSON.parse(response);
 							window.alert(getMessage('workoutImportedCorrectly'));
-							window.location.href = 'https://connect.garmin.com/modern/workout/' + copiedWorkout['workoutId'];
+							const sportTypeKey = copiedWorkout.sportType && copiedWorkout.sportType.sportTypeKey;
+							const queryString = sportTypeKey ? '?workoutType=' + encodeURIComponent(sportTypeKey) : '';
+							window.location.href = 'https://connect.garmin.com/app/workout/' + copiedWorkout['workoutId'] + queryString;
 						} catch (e) {
 							console.error('Failed to parse import response:', e);
 							alert(getMessage('errorImportResponseParsing'));


### PR DESCRIPTION
## Summary
- The new Garmin Connect web UI (under `/app/workouts` and `/app/workout/{id}`) uses CSS-module class names like `WorkoutsListContainer_createWorkoutButton__*`, `WorkoutPageContent_*`, and `WorkoutPageHeader_*`. These are not matched by the existing selectors, so neither the **Import Workout** button (workouts list) nor the **Download** button (workout detail) was being injected on the new layout.
- After a successful import, the extension redirected to `/modern/workout/{id}`. Garmin server-redirects that to `/app/workout/{id}` but **strips the query string** in the process, and the new detail page needs `?workoutType={sportTypeKey}` to render correctly — so post-import the user landed on a half-rendered page.
- This PR teaches the existing detection paths to recognise the new container/page markers and fixes the post-import redirect, with no change to legacy-UI behaviour where the existing selectors already match.

## Relationship to prior work
This PR extends the work from [`0af6598`](https://github.com/fulippo/share-your-garmin-workout/commit/0af6598) ("fix: support new Garmin Connect /app/ interface"). Garmin has since changed the create-workout container's CSS-module hash from `WorkoutsCreate_workoutCreate` to `WorkoutsListContainer_createWorkoutButton`, and the workout-detail page now exposes `WorkoutPageContent_*` / `WorkoutPageHeader_*` markers instead of the old `body-workout` / `body-workoutPage` classes. The selectors introduced in `0af6598` are kept as fallbacks so its coverage is preserved.

## Changes (one file: `share-your-workout.js`)
- **`GarminImport.getCreateWorkoutButton()`** now iterates over both the new `[class*="WorkoutsListContainer_createWorkoutButton"]` container and the previous `[class*="WorkoutsCreate_workoutCreate"]`, falling back to any `<button>` inside if the `Button_primary` query misses.
- **`GarminEvent.checkCurrentPage()`** workout-detail block now:
  - runs **before** the list-page block (more specific match first),
  - tests the URL with regex `\/workouts?\/\d+` so it accepts both `/workout/{id}` and `/workouts/{id}` (and the `/modern/` and `/app/` prefixes),
  - accepts `[class*="WorkoutPageContent"]` and `[class*="WorkoutPageHeader"]` as positive signals so detection fires reliably on slow SPA hydration.
- **`GarminEvent.checkCurrentPage()`** workout-list block also accepts `[class*="WorkoutsListContainer"]` as a positive signal.
- **`GarminImport.upload()`** now reads `sportType.sportTypeKey` from the import response and redirects to `/app/workout/{id}?workoutType={key}` directly, bypassing the `/modern/`→`/app/` server redirect that was stripping the query string.

## Why
On a current Garmin Connect account in French, viewing `https://connect.garmin.com/app/workouts` and `https://connect.garmin.com/app/workout/<id>?workoutType=running`:
- Before: neither the import nor the download button was injected, and importing landed on a workout page without `?workoutType=` so it didn't render correctly.
- After: both buttons appear next to the native primary buttons, and post-import the user lands on `/app/workout/{id}?workoutType={sportType}` and sees the workout normally.

The legacy selectors are preserved as fallbacks so older pages remain supported.

## Test plan
- [x] Reload the unpacked extension in `chrome://extensions`.
- [x] Visit `/app/workouts` → "Import Workout" appears next to "Create Workout".
- [x] Visit `/app/workout/{id}?workoutType=running` → "Download" appears next to "Send to Device".
- [x] Click Download → JSON downloads with the workout name as filename.
- [ ] Click Import → file picker opens; selecting a valid running workout JSON imports and redirects to `/app/workout/{id}?workoutType=running` with the page rendered correctly.